### PR TITLE
Add expand collapse all contexts button

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -4,13 +4,13 @@ import { getServerSession } from "next-auth/next";
 import { Session } from "next-auth";
 import { authOptions } from "@/lib/auth";
 import { TodaySection } from "@/components/today-section";
-import { ContextGroup } from "@/components/context-group";
 import { AddItemModal } from "@/components/add-item-modal";
 import { SmartTaskInput } from "@/components/smart-task-input";
 import { getTasks, getContexts } from "@/lib/data";
 import { signOutAction } from "@/lib/server-actions";
 import { Button } from "@/components/ui/button";
 import Link from "next/link";
+import { ContextsSection } from "@/components/contexts-section";
 
 export default async function Dashboard() {
   // Check authentication
@@ -111,27 +111,7 @@ export default async function Dashboard() {
         <TodaySection tasks={tasks} contexts={contexts} />
 
         {/* Context Groups */}
-        <div className="space-y-4">
-          <h2 className="text-xl font-semibold text-gray-900">Contexts</h2>
-          {sortedContexts.length > 0 ? (
-            <div className="grid grid-cols-1 gap-4">
-              {sortedContexts.map((context) => (
-                <ContextGroup
-                  key={context.id}
-                  context={context}
-                  tasks={tasks}
-                  allContexts={contexts}
-                />
-              ))}
-            </div>
-          ) : (
-            <div className="text-center py-8">
-              <p className="text-gray-500">
-                No contexts yet. Create one to get started!
-              </p>
-            </div>
-          )}
-        </div>
+        <ContextsSection contexts={sortedContexts} tasks={tasks} />
       </div>
       <div className="flex justify-center mt-2 pb-16">
         <AddItemModal contexts={contexts} />

--- a/components/context-collapsible.tsx
+++ b/components/context-collapsible.tsx
@@ -21,18 +21,32 @@ function useCollapsible() {
 interface ContextCollapsibleProps {
   children: ReactNode;
   defaultCollapsed?: boolean;
+  // When provided, the component becomes controlled
+  collapsed?: boolean;
+  onCollapsedChange?: (value: boolean) => void;
 }
 
 export function ContextCollapsible({
   children,
   defaultCollapsed = false,
+  collapsed,
+  onCollapsedChange,
 }: ContextCollapsibleProps) {
-  const [isCollapsed, setIsCollapsed] = useState(defaultCollapsed);
+  const isControlled = typeof collapsed === "boolean";
+  const [internalCollapsed, setInternalCollapsed] = useState(defaultCollapsed);
 
-  const toggle = () => setIsCollapsed(!isCollapsed);
+  const currentCollapsed = isControlled ? (collapsed as boolean) : internalCollapsed;
+
+  const toggle = () => {
+    if (isControlled) {
+      onCollapsedChange?.(!currentCollapsed);
+    } else {
+      setInternalCollapsed(!currentCollapsed);
+    }
+  };
 
   return (
-    <CollapsibleContext.Provider value={{ isCollapsed, toggle }}>
+    <CollapsibleContext.Provider value={{ isCollapsed: currentCollapsed, toggle }}>
       {children}
     </CollapsibleContext.Provider>
   );

--- a/components/context-group.tsx
+++ b/components/context-group.tsx
@@ -24,6 +24,8 @@ interface ContextGroupProps {
   context: Context;
   tasks: Task[];
   allContexts: Context[];
+  collapsed?: boolean;
+  onCollapsedChange?: (value: boolean) => void;
 }
 
 function getIconComponent(iconName: string) {
@@ -56,6 +58,8 @@ export function ContextGroup({
   context,
   tasks,
   allContexts,
+  collapsed,
+  onCollapsedChange,
 }: ContextGroupProps) {
   const [isEditContextOpen, setIsEditContextOpen] = useState(false);
   const contextTasks = tasks
@@ -89,7 +93,11 @@ export function ContextGroup({
 
   return (
     <div className="bg-white rounded-xl shadow-sm overflow-hidden">
-      <ContextCollapsible defaultCollapsed={contextTasks.length === 0}>
+      <ContextCollapsible
+        defaultCollapsed={contextTasks.length === 0}
+        collapsed={collapsed}
+        onCollapsedChange={onCollapsedChange}
+      >
         <div className={cn("py-2 px-4 text-white", context.color)}>
           <ContextCollapsibleTrigger>
             <div className="w-full flex items-center justify-between rounded-lg p-2 transition-colors">

--- a/components/contexts-section.tsx
+++ b/components/contexts-section.tsx
@@ -1,0 +1,79 @@
+"use client";
+
+import { useMemo, useState } from "react";
+import { Button } from "@/components/ui/button";
+import { ChevronDown, ChevronUp } from "lucide-react";
+import type { Context, Task } from "@/lib/data";
+import { ContextGroup } from "@/components/context-group";
+
+interface ContextsSectionProps {
+  contexts: Context[];
+  tasks: Task[];
+}
+
+export function ContextsSection({ contexts, tasks }: ContextsSectionProps) {
+  const [collapsedAll, setCollapsedAll] = useState<boolean | null>(null);
+
+  // Build a map of id -> collapsed state based on collapsedAll toggle when set
+  const collapsedById = useMemo(() => {
+    if (collapsedAll === null) return new Map<string, boolean>();
+    const m = new Map<string, boolean>();
+    for (const c of contexts) {
+      m.set(c.id, collapsedAll);
+    }
+    return m;
+  }, [collapsedAll, contexts]);
+
+  const allCollapsed = collapsedAll === true;
+  const allExpanded = collapsedAll === false;
+
+  const handleExpandAll = () => setCollapsedAll(false);
+  const handleCollapseAll = () => setCollapsedAll(true);
+
+  return (
+    <div className="space-y-4">
+      <div className="flex items-center justify-between">
+        <h2 className="text-xl font-semibold text-gray-900">Contexts</h2>
+        <div className="flex items-center gap-2">
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-gray-600 hover:text-gray-900"
+            onClick={handleExpandAll}
+            disabled={allExpanded}
+          >
+            <ChevronDown className="w-4 h-4 mr-1" /> Expand all
+          </Button>
+          <Button
+            variant="ghost"
+            size="sm"
+            className="text-gray-600 hover:text-gray-900"
+            onClick={handleCollapseAll}
+            disabled={allCollapsed}
+          >
+            <ChevronUp className="w-4 h-4 mr-1" /> Collapse all
+          </Button>
+        </div>
+      </div>
+
+      {contexts.length > 0 ? (
+        <div className="grid grid-cols-1 gap-4">
+          {contexts.map((context) => (
+            <ContextGroup
+              key={context.id}
+              context={context}
+              tasks={tasks}
+              allContexts={contexts}
+              collapsed={collapsedById.get(context.id) ?? undefined}
+              onCollapsedChange={() => {}}
+            />
+          ))}
+        </div>
+      ) : (
+        <div className="text-center py-8">
+          <p className="text-gray-500">No contexts yet. Create one to get started!</p>
+        </div>
+      )}
+    </div>
+  );
+}


### PR DESCRIPTION
Add "Expand all" and "Collapse all" buttons to the contexts section to quickly manage the visibility of all context lists.

---
<a href="https://cursor.com/background-agent?bcId=bc-f438dc58-9e68-4f7a-9270-69a5c68f92a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-f438dc58-9e68-4f7a-9270-69a5c68f92a2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

