### PR TITLE
Remove time from task date input

### DIFF
--- a/components/add-item-modal.tsx
+++ b/components/add-item-modal.tsx
@@ -216,7 +216,7 @@ export function TaskModal({
           priority: task.priority,
           contextId: task.contextId,
           dueDate: task.dueDate
-            ? new Date(task.dueDate).toISOString().slice(0, 16)
+            ? new Date(task.dueDate).toISOString().slice(0, 10)
             : "",
           type: task.type,
           habitType: task.habitType || undefined,

--- a/components/task-form.tsx
+++ b/components/task-form.tsx
@@ -298,7 +298,7 @@ export function TaskForm({
           </Label>
           <Input
             id={getFieldId("dueDate")}
-            type="datetime-local"
+            type="date"
             value={data.dueDate}
             onChange={(e) => onChange("dueDate", e.target.value)}
             className={compact ? "text-sm mt-1" : ""}


### PR DESCRIPTION
Change task dialog due date input to be date-only because time is not relevant for tasks.

---
<a href="https://cursor.com/background-agent?bcId=bc-50cef6e8-e22a-4ea7-a64c-f5d5ede86b50">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-50cef6e8-e22a-4ea7-a64c-f5d5ede86b50">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

