### PR TITLE
Fix task due date label logic

### DIFF
--- a/components/smart-task-input.tsx
+++ b/components/smart-task-input.tsx
@@ -640,9 +640,11 @@ export function SmartTaskInput({
   const formatDate = (date: Date | null) => {
     if (!date) return null;
 
-    const today = new Date();
-    const diffTime = date.getTime() - today.getTime();
-    const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+    const now = new Date();
+    const diffDays = Math.round(
+      (Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) -
+        Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())) / 86400000
+    );
 
     if (diffDays === 0) return "Today";
     if (diffDays === 1) return "Tomorrow";

--- a/components/smart-task-input.tsx
+++ b/components/smart-task-input.tsx
@@ -23,6 +23,7 @@ import {
   RotateCcw,
 } from "lucide-react";
 import { cn } from "@/lib/utils";
+import { diffInLocalCalendarDays } from "@/lib/utils";
 
 interface SmartTaskInputProps {
   contexts: Array<{
@@ -640,11 +641,7 @@ export function SmartTaskInput({
   const formatDate = (date: Date | null) => {
     if (!date) return null;
 
-    const now = new Date();
-    const diffDays = Math.round(
-      (Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) -
-        Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())) / 86400000
-    );
+    const diffDays = diffInLocalCalendarDays(date);
 
     if (diffDays === 0) return "Today";
     if (diffDays === 1) return "Tomorrow";

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -154,12 +154,14 @@ export function formatTagsForInput(tags: string[]): string {
   return tags.join(', ');
 }
 
+export function diffInLocalCalendarDays(target: Date, base: Date = new Date()): number {
+  const targetUTC = Date.UTC(target.getFullYear(), target.getMonth(), target.getDate());
+  const baseUTC = Date.UTC(base.getFullYear(), base.getMonth(), base.getDate());
+  return Math.round((targetUTC - baseUTC) / 86400000);
+}
+
 export function formatDate(date: Date): string {
-  const now = new Date();
-  const diffDays = Math.round(
-    (Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) -
-      Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())) / 86400000
-  );
+  const diffDays = diffInLocalCalendarDays(date);
 
   if (diffDays === 0) return "Today";
   if (diffDays === 1) return "Tomorrow";
@@ -179,11 +181,7 @@ export function getUrgencyColor(urgency: number): string {
 export function formatDateForTask(date: Date | null): { text: string; color: string; isOverdue: boolean } | null {
   if (!date) return null;
   
-  const now = new Date();
-  const diffDays = Math.round(
-    (Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) -
-      Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())) / 86400000
-  );
+  const diffDays = diffInLocalCalendarDays(date);
 
   if (diffDays === 0) {
     return {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -155,9 +155,11 @@ export function formatTagsForInput(tags: string[]): string {
 }
 
 export function formatDate(date: Date): string {
-  const today = new Date();
-  const diffTime = date.getTime() - today.getTime();
-  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  const now = new Date();
+  const diffDays = Math.round(
+    (Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) -
+      Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())) / 86400000
+  );
 
   if (diffDays === 0) return "Today";
   if (diffDays === 1) return "Tomorrow";
@@ -177,9 +179,11 @@ export function getUrgencyColor(urgency: number): string {
 export function formatDateForTask(date: Date | null): { text: string; color: string; isOverdue: boolean } | null {
   if (!date) return null;
   
-  const today = new Date();
-  const diffTime = date.getTime() - today.getTime();
-  const diffDays = Math.ceil(diffTime / (1000 * 60 * 60 * 24));
+  const now = new Date();
+  const diffDays = Math.round(
+    (Date.UTC(date.getFullYear(), date.getMonth(), date.getDate()) -
+      Date.UTC(now.getFullYear(), now.getMonth(), now.getDate())) / 86400000
+  );
 
   if (diffDays === 0) {
     return {


### PR DESCRIPTION
Fix task due date labels to use local calendar date comparison, resolving incorrect 'Tomorrow' labels for tasks due today.

---
<a href="https://cursor.com/background-agent?bcId=bc-c5e887ce-c341-43ee-a9a3-85dfeedf98fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-c5e887ce-c341-43ee-a9a3-85dfeedf98fe">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

