### PR TITLE
Remove urgency clamping and update popup

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,7 +63,7 @@ Each context shows a "health" percentage based only on habit completion (not reg
 
 ### Urgency System
 
-Tasks are sorted by urgency scores (0-10) that can be customized based on:
+Tasks are sorted by urgency scores that can be customized based on:
 - Project importance
 - Age of task
 - Priority level

--- a/docs/mockup.tsx
+++ b/docs/mockup.tsx
@@ -377,7 +377,7 @@ const Todone = () => {
       urgency += 1.5;
     }
 
-    return Math.min(Math.max(urgency, 0), 10); // Clamp between 0 and 10
+    return urgency;
   };
 
   const getTodayTasks = () => {

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -58,7 +58,7 @@ export function calculateUrgency(task: {
     urgency += 1.5;
   }
 
-  return Math.min(Math.max(urgency, 0), 10); // Clamp between 0 and 10
+  return urgency;
 }
 
 export function explainUrgency(task: {
@@ -133,13 +133,7 @@ export function explainUrgency(task: {
     explanation.push("No urgent tags: +0.0");
   }
 
-  const finalScore = Math.min(Math.max(urgency, 0), 10);
-  
-  if (finalScore !== urgency) {
-    explanation.push(`Clamped to range [0-10]: ${finalScore.toFixed(1)}`);
-  }
-
-  return { score: finalScore, explanation };
+  return { score: urgency, explanation };
 }
 
 export function parseTags(tagsString: string): string[] {


### PR DESCRIPTION
Remove urgency clamping from calculation and explanation to allow for a wider range of scores.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c89766b-62a5-4552-9495-c57c4ac9881f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8c89766b-62a5-4552-9495-c57c4ac9881f">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

