### PR TITLE
Calculate urgency using local calendar days

### DIFF
--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -27,16 +27,12 @@ export function calculateUrgency(task: {
   }
 
   // Age weight (older tasks get more urgent)
-  const ageInDays = Math.floor(
-    (Date.now() - task.createdAt.getTime()) / (1000 * 60 * 60 * 24)
-  );
+  const ageInDays = diffInLocalCalendarDays(new Date(), task.createdAt);
   urgency += Math.min(ageInDays * 0.1, 2.0);
 
   // Due date weight
   if (task.dueDate) {
-    const daysUntilDue = Math.floor(
-      (task.dueDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24)
-    );
+    const daysUntilDue = diffInLocalCalendarDays(task.dueDate);
     
     if (daysUntilDue < 0) {
       urgency += 3.0; // Overdue
@@ -89,18 +85,14 @@ export function explainUrgency(task: {
   }
 
   // Age weight (older tasks get more urgent)
-  const ageInDays = Math.floor(
-    (Date.now() - task.createdAt.getTime()) / (1000 * 60 * 60 * 24)
-  );
+  const ageInDays = diffInLocalCalendarDays(new Date(), task.createdAt);
   const ageWeight = Math.min(ageInDays * 0.1, 2.0);
   urgency += ageWeight;
   explanation.push(`Task age (${ageInDays} days): +${ageWeight.toFixed(1)}`);
 
   // Due date weight
   if (task.dueDate) {
-    const daysUntilDue = Math.floor(
-      (task.dueDate.getTime() - Date.now()) / (1000 * 60 * 60 * 24)
-    );
+    const daysUntilDue = diffInLocalCalendarDays(task.dueDate);
     
     if (daysUntilDue < 0) {
       urgency += 3.0;


### PR DESCRIPTION
Update urgency calculation to use `diffInLocalCalendarDays` for accurate whole-day differences.

The original calculation for task age and due date differences included time-of-day, which could lead to inconsistent urgency scores within the same calendar day. By using `diffInLocalCalendarDays`, the calculation now correctly reflects the difference in full calendar days, ensuring time-of-day is ignored as requested.

---
<a href="https://cursor.com/background-agent?bcId=bc-1e200201-4bcd-4433-bbdb-a817d87a6df9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-1e200201-4bcd-4433-bbdb-a817d87a6df9">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

