### PR TITLE
Show task context in list views

### DIFF
--- a/components/task-card.tsx
+++ b/components/task-card.tsx
@@ -4,6 +4,7 @@ import React, { useState } from "react";
 import { RotateCcw, Dumbbell, BookOpen, Flame, Wrench } from "lucide-react";
 import { formatDateForTask, evaluateUrgency, getUrgencyColor } from "@/lib/utils";
 import { getHabitStatus, getHabitDisplay } from "@/lib/habits";
+import { getContextIconComponent } from "@/lib/context-icons";
 import { cn } from "@/lib/utils";
 import { TaskToggleButton } from "./task-toggle-button";
 import { TaskModal } from "./add-item-modal";
@@ -63,6 +64,9 @@ export function TaskCard({ task, contexts }: TaskCardProps) {
     tags: task.tags,
     contextCoefficient: taskContext?.coefficient || 0,
   });
+
+  // Get context icon component for display
+  const ContextIconComponent = taskContext ? getContextIconComponent(taskContext.icon) : null;
 
   return (
     <TooltipProvider>
@@ -130,8 +134,17 @@ export function TaskCard({ task, contexts }: TaskCardProps) {
                 )}
               </div>
 
-              {(task.project || task.tags.length > 0) && (
+              {(taskContext || task.project || task.tags.length > 0) && (
                 <div className="flex items-center space-x-3 mt-1">
+                  {taskContext && ContextIconComponent && (
+                    <div className={cn(
+                      "inline-flex items-center px-1.5 py-0.5 rounded text-xs font-medium text-white",
+                      taskContext.color
+                    )}>
+                      <ContextIconComponent className="w-3 h-3 mr-1" />
+                      {taskContext.name}
+                    </div>
+                  )}
                   {task.project && (
                     <span className="text-xs text-gray-500">
                       {task.project}


### PR DESCRIPTION
Display task context (icon and color) directly in 'Top by Urgency' and 'Today & Overdue' lists to improve visibility.

---
<a href="https://cursor.com/background-agent?bcId=bc-00c1f4d3-173f-4cd2-9931-1947adaf12c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-00c1f4d3-173f-4cd2-9931-1947adaf12c2">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

