### PR TITLE
Fix context group chevron animation

### DIFF
--- a/components/context-collapsible.tsx
+++ b/components/context-collapsible.tsx
@@ -10,7 +10,7 @@ interface CollapsibleContextType {
 
 const CollapsibleContext = createContext<CollapsibleContextType | null>(null);
 
-function useCollapsible() {
+export function useCollapsible() {
   const context = useContext(CollapsibleContext);
   if (!context) {
     throw new Error("useCollapsible must be used within ContextCollapsible");


### PR DESCRIPTION
Fix chevron animation in context groups to reflect collapse/expand state.

Previously, the chevron icon was hardcoded without rotation logic. This PR extracts the context group header into a new `ContextGroupHeader` component, which uses the `useCollapsible` hook to access the collapsed state and apply a CSS transform for smooth rotation.

---
<a href="https://cursor.com/background-agent?bcId=bc-0fa9fd6a-369f-4d64-b252-11ff6b09876d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0fa9fd6a-369f-4d64-b252-11ff6b09876d">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

