### PR TITLE
Display inbox icon and color by default

### DIFF
--- a/components/add-item-modal.tsx
+++ b/components/add-item-modal.tsx
@@ -102,11 +102,16 @@ export function TaskModal({
   const [showDeleteConfirm, setShowDeleteConfirm] = useState(false);
   const [showArchiveConfirm, setShowArchiveConfirm] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  
+  // Find inbox context for default selection
+  const inboxContext = contexts.find(c => c.isInbox);
+  const fallbackContextId = defaultContextId || inboxContext?.id || "";
+  
   const [taskFormData, setTaskFormData] = useState<TaskFormData>({
     title: "",
     project: "",
     priority: "MEDIUM",
-    contextId: defaultContextId || "",
+    contextId: fallbackContextId,
     dueDate: "",
     type: "TASK",
     habitType: undefined,
@@ -169,11 +174,12 @@ export function TaskModal({
         setActiveTab("context");
       } else {
         // Adding mode - reset to defaults
+        const currentFallbackContextId = defaultContextId || inboxContext?.id || "";
         setTaskFormData({
           title: "",
           project: "",
           priority: "MEDIUM",
-          contextId: defaultContextId || "",
+          contextId: currentFallbackContextId,
           dueDate: "",
           type: "TASK",
           habitType: undefined,
@@ -191,7 +197,7 @@ export function TaskModal({
         setActiveTab("task");
       }
     }
-  }, [isOpen, task?.id, defaultContextId, contextToEdit?.id]); // eslint-disable-line react-hooks/exhaustive-deps
+  }, [isOpen, task?.id, defaultContextId, contextToEdit?.id, inboxContext?.id]); // eslint-disable-line react-hooks/exhaustive-deps
 
   const handleTaskFormChange = <K extends keyof TaskFormData>(
     field: K,

--- a/components/task-form.tsx
+++ b/components/task-form.tsx
@@ -75,6 +75,13 @@ export function TaskForm({
   const gap = compact ? "gap-2" : "gap-4";
   const spacing = compact ? "space-y-2" : "space-y-4";
 
+  // Find inbox context for default selection
+  const inboxContext = contexts.find(c => c.isInbox);
+  
+  // Get the selected context or default to inbox
+  const selectedContextId = data.contextId || inboxContext?.id || "";
+  const selectedContext = contexts.find(c => c.id === selectedContextId);
+
   return (
     <div className={spacing}>
       <div className={`grid ${gridCols} ${gap}`}>
@@ -174,11 +181,27 @@ export function TaskForm({
             Context
           </Label>
           <Select
-            value={data.contextId}
+            value={selectedContextId}
             onValueChange={(value) => onChange("contextId", value)}
           >
             <SelectTrigger className={compact ? "text-sm mt-1" : ""}>
-              <SelectValue placeholder="Inbox (default)" />
+              <SelectValue placeholder="Inbox (default)">
+                {selectedContext && (
+                  <div className="flex items-center">
+                    <div
+                      className={`w-3 h-3 rounded-full ${selectedContext.color} mr-2`}
+                    />
+                    {(() => {
+                      const IconComponent = getContextIconComponent(selectedContext.icon);
+                      return <IconComponent className="w-4 h-4 mr-2" />;
+                    })()}
+                    {selectedContext.name}
+                    {selectedContext.isInbox && (
+                      <span className="text-xs text-gray-500 ml-2">(default)</span>
+                    )}
+                  </div>
+                )}
+              </SelectValue>
             </SelectTrigger>
             <SelectContent>
               {contexts


### PR DESCRIPTION
Display the default 'Inbox' context with its icon and color in the task creation form.

Previously, when 'Inbox' was automatically selected as the default context, it appeared as plain text without its associated icon and color styling. This update ensures the default selection is visually consistent with manually chosen contexts, providing immediate clarity to the user.

---
<a href="https://cursor.com/background-agent%3FbcId=bc-3ab879b1-8291-47ca-bb95-90dd0df60656">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents%3Fid=bc-3ab879b1-8291-47ca-bb95-90dd0df60656">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>