### PR TITLE
Fix smart task input context display

### DIFF
--- a/components/smart-task-input.tsx
+++ b/components/smart-task-input.tsx
@@ -829,9 +829,19 @@ export function SmartTaskInput({
                       >
                         {parsedTask.contextName} (not found)
                       </Badge>
-                    ) : (
-                      <span className="text-red-400">No context selected</span>
-                    )}
+                    ) : (() => {
+                      const inboxContext = contexts.find(c => c.isInbox);
+                      return inboxContext ? (
+                        <Badge
+                          variant="outline"
+                          className="text-blue-600 bg-blue-50 border-blue-200"
+                        >
+                          {inboxContext.name} (default)
+                        </Badge>
+                      ) : (
+                        <span className="text-red-400">No context available</span>
+                      );
+                    })()}
                   </div>
                 </div>
 


### PR DESCRIPTION
Default smart task input preview context to Inbox when none is selected to match task form behavior.

The smart task input's preview previously displayed "No context selected" when a context wasn't explicitly chosen, despite the underlying system defaulting tasks to the Inbox context, similar to the task form modal. This change aligns the preview's display with the actual default behavior, showing "Inbox (default)" instead.

---
<a href="https://cursor.com/background-agent?bcId=bc-8c8589dc-9add-4be7-8a2d-44ad4df341d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-8c8589dc-9add-4be7-8a2d-44ad4df341d8">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

