### PR TITLE
Remove focus from complete yesterday button

### DIFF
--- a/components/add-item-modal.tsx
+++ b/components/add-item-modal.tsx
@@ -367,36 +367,6 @@ export function TaskModal({
                 ? "Edit Context"
                 : "Add New Item"}
             </DialogTitle>
-            
-            {/* Quick Actions in Header - Only for editing tasks */}
-            {isEditing && activeTab === "task" && (
-              <div className="flex items-center space-x-2">
-                {!task?.completed && (
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="sm"
-                    onClick={handleCompleteYesterday}
-                    disabled={isLoading}
-                    className="text-xs"
-                  >
-                    <Calendar className="w-3 h-3 mr-1" />
-                    Complete Yesterday
-                  </Button>
-                )}
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="sm"
-                  onClick={() => setShowDeleteConfirm(true)}
-                  disabled={isLoading}
-                  className="text-xs text-red-600 hover:text-red-700 hover:bg-red-50"
-                >
-                  <Trash2 className="w-3 h-3 mr-1" />
-                  Delete
-                </Button>
-              </div>
-            )}
           </div>
         </DialogHeader>
 
@@ -458,6 +428,41 @@ export function TaskModal({
               task={task}
               fieldIdPrefix={modalId}
             />
+
+            {/* Quick Actions for editing tasks - moved from header */}
+            {isEditing && (
+              <div className="flex items-center justify-between pt-2 pb-2 border-t border-gray-100">
+                <div className="text-sm text-gray-600">
+                  Quick Actions:
+                </div>
+                <div className="flex items-center space-x-2">
+                  {!task?.completed && (
+                    <Button
+                      type="button"
+                      variant="ghost"
+                      size="sm"
+                      onClick={handleCompleteYesterday}
+                      disabled={isLoading}
+                      className="text-xs"
+                    >
+                      <Calendar className="w-3 h-3 mr-1" />
+                      Complete Yesterday
+                    </Button>
+                  )}
+                  <Button
+                    type="button"
+                    variant="ghost"
+                    size="sm"
+                    onClick={() => setShowDeleteConfirm(true)}
+                    disabled={isLoading}
+                    className="text-xs text-red-600 hover:text-red-700 hover:bg-red-50"
+                  >
+                    <Trash2 className="w-3 h-3 mr-1" />
+                    Delete
+                  </Button>
+                </div>
+              </div>
+            )}
 
             <div className="flex justify-end space-x-2 pt-4">
               <Button type="button" variant="outline" onClick={onClose}>


### PR DESCRIPTION
Move quick action buttons in task edit modal to prevent unwanted auto-focus on 'Complete Yesterday' button.

---
<a href="https://cursor.com/background-agent?bcId=bc-045aae9a-1150-46a3-9444-a1169d928a9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-045aae9a-1150-46a3-9444-a1169d928a9e">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

