### PR TITLE
Enable markdown formatting for task cards

### DIFF
--- a/components/task-card.tsx
+++ b/components/task-card.tsx
@@ -21,6 +21,7 @@ import { getContextIconComponent } from "@/lib/context-icons";
 import { cn } from "@/lib/utils";
 import { TaskToggleButton } from "./task-toggle-button";
 import { TaskModal } from "./add-item-modal";
+import { MarkdownText } from "@/components/ui/markdown-text";
 import {
   Tooltip,
   TooltipContent,
@@ -93,7 +94,9 @@ const renderSubtaskDisplay = (subtasks: Array<{id: string; text: string; complet
                 {subtask.completed ? "✓" : "○"}
               </span>
               <span className={subtask.completed ? "line-through text-gray-400" : ""}>
-                {subtask.text.length > 30 ? `${subtask.text.substring(0, 30)}...` : subtask.text}
+                <MarkdownText 
+                  text={subtask.text.length > 30 ? `${subtask.text.substring(0, 30)}...` : subtask.text}
+                />
               </span>
             </div>
           ))}
@@ -182,7 +185,7 @@ export function TaskCard({
                   onClick={() => setIsEditModalOpen(true)}
                   title="Click to edit task"
                 >
-                  {task.title}
+                  <MarkdownText text={task.title} />
                 </h3>
 
                 {task.type === "RECURRING" && (
@@ -265,9 +268,11 @@ export function TaskCard({
                       </TooltipTrigger>
                       <TooltipContent>
                         <p className="text-xs max-w-xs">
-                          {task.notes.length > 100
-                            ? `${task.notes.substring(0, 100)}...`
-                            : task.notes}
+                          <MarkdownText 
+                            text={task.notes.length > 100
+                              ? `${task.notes.substring(0, 100)}...`
+                              : task.notes}
+                          />
                         </p>
                       </TooltipContent>
                     </Tooltip>

--- a/components/ui/markdown-text.tsx
+++ b/components/ui/markdown-text.tsx
@@ -1,5 +1,5 @@
-import React from 'react';
-import { cn } from '@/lib/utils';
+import React from "react";
+import { cn } from "@/lib/utils";
 
 interface MarkdownTextProps {
   text: string;
@@ -15,9 +15,9 @@ export function MarkdownText({ text, className }: MarkdownTextProps) {
 
     // Regex patterns for different markdown elements
     const patterns = [
-      { regex: /`([^`]+)`/g, type: 'code' },           // `code`
-      { regex: /\*\*([^*]+)\*\*/g, type: 'bold' },     // **bold**
-      { regex: /_([^_]+)_/g, type: 'italic' },         // _italic_
+      { regex: /`([^`]+)`/g, type: "code" }, // `code`
+      { regex: /\*\*([^*]+)\*\*/g, type: "bold" }, // **bold**
+      { regex: /_([^_]+)_/g, type: "italic" }, // _italic_
     ];
 
     // Find all matches and their positions
@@ -49,11 +49,14 @@ export function MarkdownText({ text, className }: MarkdownTextProps) {
     // Remove overlapping matches (keep the first one)
     const validMatches: typeof matches = [];
     for (const match of matches) {
-      if (!validMatches.some(vm => 
-        (match.start >= vm.start && match.start < vm.end) ||
-        (match.end > vm.start && match.end <= vm.end) ||
-        (match.start <= vm.start && match.end >= vm.end)
-      )) {
+      if (
+        !validMatches.some(
+          (vm) =>
+            (match.start >= vm.start && match.start < vm.end) ||
+            (match.end > vm.start && match.end <= vm.end) ||
+            (match.start <= vm.start && match.end >= vm.end)
+        )
+      ) {
         validMatches.push(match);
       }
     }
@@ -70,24 +73,24 @@ export function MarkdownText({ text, className }: MarkdownTextProps) {
 
       // Add the formatted match
       switch (match.type) {
-        case 'code':
+        case "code":
           parts.push(
             <code
               key={`code-${partIndex++}`}
-              className="bg-gray-100 text-gray-600 px-1 py-0.5 rounded text-xs font-mono"
+              className="bg-gray-200 text-gray-800 px-1.5 py-0.5 rounded-sm font-mono text-[11px] border border-gray-300 inline align-middle"
             >
               {match.content}
             </code>
           );
           break;
-        case 'bold':
+        case "bold":
           parts.push(
             <strong key={`bold-${partIndex++}`} className="font-semibold">
               {match.content}
             </strong>
           );
           break;
-        case 'italic':
+        case "italic":
           parts.push(
             <em key={`italic-${partIndex++}`} className="italic">
               {match.content}
@@ -118,8 +121,6 @@ export function MarkdownText({ text, className }: MarkdownTextProps) {
   const parsedContent = parseInlineMarkdown(text);
 
   return (
-    <span className={cn("markdown-text", className)}>
-      {parsedContent}
-    </span>
+    <span className={cn("markdown-text", className)}>{parsedContent}</span>
   );
 }

--- a/components/ui/markdown-text.tsx
+++ b/components/ui/markdown-text.tsx
@@ -1,0 +1,125 @@
+import React from 'react';
+import { cn } from '@/lib/utils';
+
+interface MarkdownTextProps {
+  text: string;
+  className?: string;
+}
+
+export function MarkdownText({ text, className }: MarkdownTextProps) {
+  // Simple inline markdown parser for basic formatting
+  const parseInlineMarkdown = (input: string): React.ReactElement[] => {
+    const parts: React.ReactElement[] = [];
+    let currentIndex = 0;
+    let partIndex = 0;
+
+    // Regex patterns for different markdown elements
+    const patterns = [
+      { regex: /`([^`]+)`/g, type: 'code' },           // `code`
+      { regex: /\*\*([^*]+)\*\*/g, type: 'bold' },     // **bold**
+      { regex: /_([^_]+)_/g, type: 'italic' },         // _italic_
+    ];
+
+    // Find all matches and their positions
+    const matches: Array<{
+      start: number;
+      end: number;
+      content: string;
+      type: string;
+      match: string;
+    }> = [];
+
+    patterns.forEach(({ regex, type }) => {
+      let match;
+      const tempRegex = new RegExp(regex.source, regex.flags);
+      while ((match = tempRegex.exec(input)) !== null) {
+        matches.push({
+          start: match.index,
+          end: match.index + match[0].length,
+          content: match[1],
+          type,
+          match: match[0],
+        });
+      }
+    });
+
+    // Sort matches by start position
+    matches.sort((a, b) => a.start - b.start);
+
+    // Remove overlapping matches (keep the first one)
+    const validMatches: typeof matches = [];
+    for (const match of matches) {
+      if (!validMatches.some(vm => 
+        (match.start >= vm.start && match.start < vm.end) ||
+        (match.end > vm.start && match.end <= vm.end) ||
+        (match.start <= vm.start && match.end >= vm.end)
+      )) {
+        validMatches.push(match);
+      }
+    }
+
+    // Build the result
+    validMatches.forEach((match) => {
+      // Add text before the match
+      if (match.start > currentIndex) {
+        const textBefore = input.substring(currentIndex, match.start);
+        if (textBefore) {
+          parts.push(<span key={`text-${partIndex++}`}>{textBefore}</span>);
+        }
+      }
+
+      // Add the formatted match
+      switch (match.type) {
+        case 'code':
+          parts.push(
+            <code
+              key={`code-${partIndex++}`}
+              className="bg-gray-100 text-gray-600 px-1 py-0.5 rounded text-xs font-mono"
+            >
+              {match.content}
+            </code>
+          );
+          break;
+        case 'bold':
+          parts.push(
+            <strong key={`bold-${partIndex++}`} className="font-semibold">
+              {match.content}
+            </strong>
+          );
+          break;
+        case 'italic':
+          parts.push(
+            <em key={`italic-${partIndex++}`} className="italic">
+              {match.content}
+            </em>
+          );
+          break;
+      }
+
+      currentIndex = match.end;
+    });
+
+    // Add remaining text
+    if (currentIndex < input.length) {
+      const remainingText = input.substring(currentIndex);
+      if (remainingText) {
+        parts.push(<span key={`text-${partIndex++}`}>{remainingText}</span>);
+      }
+    }
+
+    // If no matches found, return the original text
+    if (parts.length === 0) {
+      parts.push(<span key="original">{input}</span>);
+    }
+
+    return parts;
+  };
+
+  const parsedContent = parseInlineMarkdown(text);
+
+  return (
+    <span className={cn("markdown-text", className)}>
+      {parsedContent}
+    </span>
+  );
+}


### PR DESCRIPTION
Add inline markdown support for task card text fields to allow monospaced, bold, and italic formatting.

---
<a href="https://cursor.com/background-agent?bcId=bc-d35ceb21-83d2-4e75-b889-fd8285b8f17c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-d35ceb21-83d2-4e75-b889-fd8285b8f17c">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

